### PR TITLE
Avoid JSON errors with interval > 27263

### DIFF
--- a/Classes/RateLimiter/Storage/FileStorage.php
+++ b/Classes/RateLimiter/Storage/FileStorage.php
@@ -39,7 +39,7 @@ final class FileStorage implements StorageInterface
 
         \file_put_contents(
             $this->getFilePath($limiterState->getId()),
-            \json_encode($content, \JSON_THROW_ON_ERROR)
+            \serialize($content)
         );
     }
 
@@ -55,12 +55,8 @@ final class FileStorage implements StorageInterface
             return null;
         }
 
-        try {
-            /** @var array{state: string, expiry: int} $data */
-            $data = \json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
-        } catch (\JsonException $e) {
-            return null;
-        }
+        /** @var array{state: string, expiry: int} $data */
+        $data = \unserialize($content);
 
         $state = \unserialize($data['state'], [
             'allowed_classes' => [Window::class, SlidingWindow::class],

--- a/Classes/RateLimiter/Storage/FileStorageCleaner.php
+++ b/Classes/RateLimiter/Storage/FileStorageCleaner.php
@@ -54,17 +54,13 @@ class FileStorageCleaner
         $this->count->incrementTotal();
 
         $content = \file_get_contents($file->getPathname());
+
         if ($content === false) {
             $this->count->incrementErroneous();
             return;
         }
-        try {
-            /** @var array{state: string, expiry: int} $data */
-            $data = \json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
-        } catch (\JsonException $e) {
-            $this->count->incrementErroneous();
-            return;
-        }
+
+        $data = \unserialize($content);
 
         if ($data['expiry'] >= \time()) {
             return;

--- a/Tests/Unit/RateLimiter/Storage/FileStorageCleanerTest.php
+++ b/Tests/Unit/RateLimiter/Storage/FileStorageCleanerTest.php
@@ -114,6 +114,6 @@ final class FileStorageCleanerTest extends TestCase
         $data = [
             'expiry' => $expiry,
         ];
-        \file_put_contents($filePath, \json_encode($data, \JSON_THROW_ON_ERROR));
+        \file_put_contents($filePath, \serialize($data));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     },
     "require": {
         "php": ">=7.4",
-        "ext-json": "*",
         "symfony/rate-limiter": "^5.4 || ^6.2",
         "typo3/cms-core": "^11.5.3 || ^12.4",
         "typo3/cms-fluid": "^11.5.3 || ^12.4",


### PR DESCRIPTION
Long story short: JSON encoding a serialized PHP object can fail due to invalid UTF-8 characters.

Avoid this by serializing the whole storage entry instead. This basically leads to double-serialization of the limiter state but this is actually no problem.

Technically we'd also need an upgrade wizard or similar to migrate existing JSON-based entries but this is beyond my time.

Fixes #5