### PR TITLE
[BUGFIX] Fix site set label

### DIFF
--- a/Configuration/Sets/FormRateLimit/config.yaml
+++ b/Configuration/Sets/FormRateLimit/config.yaml
@@ -1,5 +1,5 @@
 name: brotkrueml/form-rate-limit
-label: CodeHighlight
+label: Form Rate Limit
 
 dependencies:
   - typo3/form


### PR DESCRIPTION
Obviously, the site set label of EXT:codehighlight was retained here by mistake.