### PR TITLE
Make the cleanup command schedulable

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -37,7 +37,6 @@ return static function(ContainerConfigurator $configurator) {
         ->tag('console.command', [
             'command' => 'formratelimit:cleanupexpiredstorageentries',
             'description' => 'Clean up expired storage entries of form_rate_limit extension',
-            'schedulable' => false,
         ]);
 
     $services->set(PreventLanguagePackDownload::class)

--- a/Documentation/Command/Index.rst
+++ b/Documentation/Command/Index.rst
@@ -26,4 +26,4 @@ can call it on the console with:
 
          typo3/sysext/core/bin/typo3 formratelimit:cleanupexpiredstorageentries
 
-You can add a cron job to run regularly.
+To run the command regularly you can add a cron job or run it from the TYPO3 scheduler.


### PR DESCRIPTION
The formratelimit:cleanupexpiredstorageentries command can now be run from the TYPO3 scheduler.